### PR TITLE
feature: remove the target parameter from sign-digest.yml

### DIFF
--- a/.github/workflows/actions-example.yml
+++ b/.github/workflows/actions-example.yml
@@ -32,7 +32,6 @@ jobs:
     needs: build
     uses: sillsdev/codesign/.github/workflows/sign-digest.yml@v1
     with:
-      target: grcompiler.exe
       digest: ${{needs.build.outputs.digest}}
   
   attach:

--- a/.github/workflows/sign-digest.yml
+++ b/.github/workflows/sign-digest.yml
@@ -8,9 +8,6 @@ on:
       hash:
         default: "sha256"
         type: string
-      target:
-        required: true
-        type: string
       digest:
         required: true
         type: string

--- a/.github/workflows/sign.yml
+++ b/.github/workflows/sign.yml
@@ -44,7 +44,6 @@ jobs:
     needs: digest
     uses: sillsdev/codesign/.github/workflows/sign-digest.yml@v1
     with:
-      target: ${{inputs.target}}
       digest: ${{needs.digest.outputs.digest}}
    
   finalise:

--- a/.github/workflows/test-sign-digest.yml
+++ b/.github/workflows/test-sign-digest.yml
@@ -11,7 +11,6 @@ jobs:
   sign:
     uses: ./.github/workflows/sign-digest.yml
     with:
-      target: ssh-test-setup.exe
       digest: "egf6ayf/Osfooq7xfsR5SjjvbGdMXVbtQZKe0aR8djQ="
 
   check:


### PR DESCRIPTION
It is not required for signing a digest, only for signing a file, which is handled by sign.yml and the actions.