### PR TITLE
Add a simplified interface to Azure trusted singing action

### DIFF
--- a/.github/workflows/sign-example.yml
+++ b/.github/workflows/sign-example.yml
@@ -15,6 +15,7 @@ jobs:
     
     - uses: sillsdev/codesign/trusted-signing-action@feat/trusted-signing-service-action
       with:
+        account: TRUSTED_SIGNING_TEST_CERT
         files: |
           ${{ github.workspace }}\grcompiler.exe
           ${{ github.workspace }}\gdlpp.exe

--- a/.github/workflows/sign-example.yml
+++ b/.github/workflows/sign-example.yml
@@ -15,7 +15,8 @@ jobs:
     
     - uses: sillsdev/codesign/trusted-signing-action@feat/trusted-signing-service-action
       with:
-        account: TRUSTED_SIGNING_TEST_CERT
+        authentication: ${{ secrets.AZURE_TRUSTED_SIGNING_CREDENTIALS}}
+        account: ${{ vars.TRUSTED_SIGNING_TEST_CERT }}
         files: |
           ${{ github.workspace }}\grcompiler.exe
           ${{ github.workspace }}\gdlpp.exe

--- a/.github/workflows/sign-example.yml
+++ b/.github/workflows/sign-example.yml
@@ -16,7 +16,6 @@ jobs:
     - uses: sillsdev/codesign/trusted-signing-action@feat/trusted-signing-service-action
       with:
         credentials: ${{ secrets.TRUSTED_SIGNING_CREDENTIALS}}
-        use-test-certificate: true
         files-folder: .
         files-folder-filter: exe
         description: Graphite Description Language compiler

--- a/.github/workflows/sign-example.yml
+++ b/.github/workflows/sign-example.yml
@@ -17,6 +17,7 @@ jobs:
       with:
         credentials: ${{ secrets.TRUSTED_SIGNING_CREDENTIALS}}
         use-test-certificate: true
+        files-folder: .
         files-folder-filter: exe
         description: Graphite Description Language compiler
         description-url: https://graphite.sil.org

--- a/.github/workflows/sign-example.yml
+++ b/.github/workflows/sign-example.yml
@@ -4,10 +4,8 @@ on:
     paths:
     - .github/workflows/sign.yml
     - .github/workflows/sign-example.yml
-    - apply-signed-digest/**
-    - generate-digest/**
-    - timestamp/**
     - verify-signature/**
+    - trusted-signing-action/**
 
 jobs:
   build:

--- a/.github/workflows/sign-example.yml
+++ b/.github/workflows/sign-example.yml
@@ -4,8 +4,10 @@ on:
     paths:
     - .github/workflows/sign.yml
     - .github/workflows/sign-example.yml
+    - apply-signed-digest/**
+    - generate-digest/**
+    - timestamp/**
     - verify-signature/**
-    - trusted-signing-action/**
 
 jobs:
   build:
@@ -13,15 +15,33 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     
-    - uses: sillsdev/codesign/trusted-signing-action@feat/trusted-signing-service-action
+    - name: Upload job to be signed
+      uses: actions/upload-artifact@v4
       with:
-        credentials: ${{ secrets.TRUSTED_SIGNING_CREDENTIALS}}
-        files-folder: .
-        files-folder-filter: exe
-        description: Graphite Description Language compiler
-        description-url: https://graphite.sil.org
+        name: grcompiler
+        path: g*.exe
+
+  sign:
+    needs: build
+    uses: sillsdev/codesign/.github/workflows/sign.yml@v2.1
+    with:
+      artifact: grcompiler
+      description: Graphite
+    secrets:
+      certificate: ${{ secrets.CODESIGN_LSDEVSECTIGOEV }}
+
+  test:
+    runs-on: windows-latest
+    needs: sign
+    env:
+      signtool: C:/"Program Files (x86)"/"Windows Kits"/10/bin/10.0.17763.0/x86/signtool.exe
+    steps:
+    - name: Download signed and timestamped job
+      uses: actions/download-artifact@v4
+      with:
+        name: grcompiler
 
     - name: Confirm signature
-      uses: sillsdev/codesign/verify-signature@feat/trusted-signing-service-action
+      uses: sillsdev/codesign/verify-signature@v2
       with:
         path: g*.exe

--- a/.github/workflows/sign-example.yml
+++ b/.github/workflows/sign-example.yml
@@ -15,11 +15,9 @@ jobs:
     
     - uses: sillsdev/codesign/trusted-signing-action@feat/trusted-signing-service-action
       with:
-        authentication: ${{ secrets.AZURE_TRUSTED_SIGNING_CREDENTIALS}}
-        account: ${{ vars.TRUSTED_SIGNING_TEST_CERT }}
-        files: |
-          ${{ github.workspace }}\grcompiler.exe
-          ${{ github.workspace }}\gdlpp.exe
+        credentials: ${{ secrets.TRUSTED_SIGNING_CREDENTIALS}}
+        use-test-certificate: true
+        files-folder-filter: exe
         description: Graphite Description Language compiler
         description-url: https://graphite.sil.org
 

--- a/.github/workflows/sign-example.yml
+++ b/.github/workflows/sign-example.yml
@@ -15,33 +15,15 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     
-    - name: Upload job to be signed
-      uses: actions/upload-artifact@v4
+    - uses: sillsdev/codesign/trusted-signing-action@feat/trusted-signing-service-action
       with:
-        name: grcompiler
-        path: g*.exe
-
-  sign:
-    needs: build
-    uses: sillsdev/codesign/.github/workflows/sign.yml@v2.1
-    with:
-      artifact: grcompiler
-      description: Graphite
-    secrets:
-      certificate: ${{ secrets.CODESIGN_LSDEVSECTIGOEV }}
-
-  test:
-    runs-on: windows-latest
-    needs: sign
-    env:
-      signtool: C:/"Program Files (x86)"/"Windows Kits"/10/bin/10.0.17763.0/x86/signtool.exe
-    steps:
-    - name: Download signed and timestamped job
-      uses: actions/download-artifact@v4
-      with:
-        name: grcompiler
+        files: |
+          ${{ github.workspace }}\grcompiler.exe
+          ${{ github.workspace }}\gdlpp.exe
+        description: Graphite Description Language compiler
+        description-url: https://graphite.sil.org
 
     - name: Confirm signature
-      uses: sillsdev/codesign/verify-signature@v2
+      uses: sillsdev/codesign/verify-signature@feat/trusted-signing-service-action
       with:
         path: g*.exe

--- a/.github/workflows/sign-trusted-signing-example.yml
+++ b/.github/workflows/sign-trusted-signing-example.yml
@@ -1,0 +1,27 @@
+name: Demonstrate simple sign.yml workflow.
+on:
+  push:
+    paths:
+    - .github/workflows/sign.yml
+    - .github/workflows/sign-example.yml
+    - verify-signature/**
+    - trusted-signing-action/**
+
+jobs:
+  sign:
+    runs-on: windows-latest
+    steps:
+    - uses: actions/checkout@v4
+    
+    - uses: sillsdev/codesign/trusted-signing-action@feat/trusted-signing-service-action
+      with:
+        credentials: ${{ secrets.TRUSTED_SIGNING_CREDENTIALS}}
+        files-folder: .
+        files-folder-filter: exe
+        description: Graphite Description Language compiler
+        description-url: https://graphite.sil.org
+
+    - name: Confirm signature
+      uses: sillsdev/codesign/verify-signature@feat/trusted-signing-service-action
+      with:
+        path: g*.exe

--- a/.github/workflows/sign-trusted-signing-example.yml
+++ b/.github/workflows/sign-trusted-signing-example.yml
@@ -1,4 +1,4 @@
-name: Demonstrate simple sign.yml workflow.
+name: Demonstrate simple trusted-signing-action.
 on:
   push:
     paths:

--- a/.github/workflows/sign-trusted-signing-example.yml
+++ b/.github/workflows/sign-trusted-signing-example.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     
-    - uses: sillsdev/codesign/trusted-signing-action@feat/trusted-signing-service-action
+    - uses: sillsdev/codesign/trusted-signing-action@v3
       with:
         credentials: ${{ secrets.TRUSTED_SIGNING_CREDENTIALS}}
         files-folder: .
@@ -22,6 +22,6 @@ jobs:
         description-url: https://graphite.sil.org
 
     - name: Confirm signature
-      uses: sillsdev/codesign/verify-signature@feat/trusted-signing-service-action
+      uses: sillsdev/codesign/verify-signature@v3
       with:
         path: g*.exe

--- a/README.md
+++ b/README.md
@@ -1,6 +1,92 @@
 # Codesign [![sign.yml reusable workflow.](https://github.com/sillsdev/codesign/actions/workflows/sign-example.yml/badge.svg)](https://github.com/sillsdev/codesign/actions/workflows/sign-example.yml)
 
-This contains a front end reusable workflow `sign.yml`, and the actions and subworkflow that implement it along with tests/examples showing how to use them.
+This contains a facade action to Microsofts [azure/trusted-signing-action](https://github.com/Azure/trusted-signing-action), which takes care of setting required presets, and hides of the many account and authentication parameters in a secret JSON bundle. This action passes through all other parameters for selecting files to sign, and specifying descriptions. It reduces the `certificate-profile-name` input to a binary choice between our production and non-validating test certs.
+
+Please see further down for the documentation for the original [v2 documentation](#Deprecated-v2-Actions-and-Workflow-documentation)
+
+
+## Runner requirements
+
+All the actions in the repo will only run on a windows runner, the GitHub hosted windows runner will work as will self-hosted runners with Windows 7+ which have Powershell 5.1+, and .NET runtime 6.0+
+
+## Example
+
+An example from an MSIX packaged app:
+```yaml
+- name: Sign with Trusted Signing
+  uses: sillsdev/codesign/trusted-signing-action@v3
+  with:
+    credentials: ${{ secrets.TRUSTED_SIGNING_CREDENTIALS }}
+    files-folder: ${{ github.workspace }}/artifacts/
+    files-folder-filter: msixbundle,exe
+    files-folder-recurse: true
+    files-folder-depth: 4
+    description:  'Release for version ${{ needs.build.outputs.version }} from branch ${{ github.ref_name }}'
+    description-url: 'https://example.com'
+```
+
+## Usage
+
+These are the specific inputs for the `sillsdev/codesign/trusted-signing-action`, unless indicate othewise you can use the same parameters as the underlying azure version.
+
+
+### Authentication
+
+This Action connects to the Azure service via OpenID Connect only we don't support any of the other authentication mechanisms. All the account and authentication parameters are supplied via a secret JSON bundle defined like so:
+```json
+{
+  "tenant-id": "<Entra Directory ID>",
+  "client-id": "<Entra Application ID>",
+  "client-secret": "<Secret value, not secret ID>",
+  "endpoint": "<end point the in the country your account is in>",
+  "account-name": "<account name>"
+}
+```
+We provide this bundle as an Organizational secret visible to selected repos called `TRUSTED_SIGNING_CREDENTIALS`.
+
+### Test signing
+```yaml
+use-test-certificate: true
+```
+Don't use the Public Trust production certificate, instead use the Public Trust Test cert. This is guarenteed not validate. Defaults to 'false'.
+
+
+## Azure action parameters
+### Supported
+We pass the following inputs through verbatim:
+* `files`
+* `files-folder`
+* `files-folder-filter`
+* `files-folder-recurse`
+* `files-folder-depth`
+* `files-catalog`
+* `description`
+* `description-url`
+* `timeout`
+* `batch-size`
+* `trace` except if the runner is debug mode, then it is always on
+
+### Unsupported
+The following parameters from the Azure Action are not accepted as they are supplied by, or superceded by this Actions `credentials` parameter:
+* `azure-tenant-id`
+* `azure-client-id`
+* `azure-client-secret`
+* `azure-username`
+* `azure-password`
+* `endpoint`
+* `trusted-signing-account-name`
+
+The following Azure parameters predefined by this Action, and so not accepted:
+* `certificate-profile-name` derived from `use-test-certificate`
+* `file-digest` set to SHA256
+* `timestamp-rfc3161` always uses http://timestamp.acs.microsoft.com
+* `timestamp-digest` set to SHA256
+* all `exclude-*-credential` inputs
+
+
+
+# Deprecated v2 Actions and Workflow documentation
+The repo also contains the now deprecated front end reusable workflow `sign.yml`, and the actions and subworkflow that implement it along with tests/examples showing how to use them. These are effectively halting development and v2.1.
 
 The simplest interface is the `sillsdev/codesign/.github/workflows/sign.yml` reusable workflow. This allows the signing of a multiple files, by calling into `sillsdev/codesign/.github/workflows/sign-digest.yml` to pass the detached digest for signing on our in-house code signing system. Files to be signed must be passed in an artifact, which will be overwritten with the signed versions when the `sign-digest.yml` workflow completes.
 
@@ -14,7 +100,7 @@ There are a several actions that facilitate more integrapted use of sign-digest.
 
 The generate-digest, timestamp, and verify-signature actions take a `path:` parameter that works the same way as `actions/upload-artifact`'s `path:` parameter, allowing you to specify files using a set of globs or filenames, one per line. e.g.:
 ```yaml
-      uses: sillsdev/codesign/generate-digest@improve-multiple-signing
+      uses: sillsdev/codesign/generate-digest@v2
       with:
         path: |
           gdlpp.exe

--- a/trusted-signing-action/action.yml
+++ b/trusted-signing-action/action.yml
@@ -4,11 +4,11 @@ author: tim-seves
 inputs:
   authentication:
     description: A JSON object containing the credentials to authenticate us to the Trusted Signing Service.
-    default: ${{ secrets.AZURE_TRUSTED_SIGNING_CREDENTIALS }}
+    default: AZURE_TRUSTED_SIGNING_CREDENTIALS
     required: false
   account:
     description: A JSON object containing the endpoing, account and certificate identification
-    default: ${{ vars.TRUSTED_SIGNING_CERTIFICATE_ENDPOINT }}
+    default: TRUSTED_SIGNING_CERTIFICATE_ENDPOINT
     required: false
   files:
     description: A comma or newline separated list of absolute paths to the files being signed. Can be combined
@@ -57,7 +57,7 @@ inputs:
 runs:
   using: composite
   steps:
-  - uses: azure/trusted-signing-action
+  - uses: azure/trusted-signing-action@0.4.0
     with: 
       exclude-environment-credential: false
       exclude-workload-identity-credential: true
@@ -73,12 +73,12 @@ runs:
       timestamp-rfc3161: http://timestamp.acs.microsoft.com
       timestamp-digest: SHA256
       trace: ${{ runner.debug == '1' }}
-      azure-tenant-id: ${{ fromJSON(inputs.authentication).tenant-id }}
-      azure-client-id: ${{ fromJSON(inputs.authentication).client-id }}
-      azure-client-secret: ${{ fromJSON(inputs.authentication).client-secret }}
-      endpoint: ${{ fromJSON(inputs.account).endpoint }}
-      trusted-signing-account-name: ${{ fromJSON(inputs.account).account-name }}
-      certificate-profile-name: ${{ fromJSON(inputs.account).profile-name }}
+      azure-tenant-id: ${{ fromJSON(secrets[inputs.authentication]).tenant-id }}
+      azure-client-id: ${{ fromJSON(secrets[inputs.authentication]).client-id }}
+      azure-client-secret: ${{ fromJSON(secrets[inputs.authentication]).client-secret }}
+      endpoint: ${{ fromJSON(vars[inputs.account]).endpoint }}
+      trusted-signing-account-name: ${{ fromJSON(vars[inputs.account]).account-name }}
+      certificate-profile-name: ${{ fromJSON(vars[inputs.account]).profile-name }}
       files: ${{ inputs.files }}
       files-folder: ${{ inputs.files-folder }}
       files-folder-filter: ${{ inputs.files-folder-filter }}

--- a/trusted-signing-action/action.yml
+++ b/trusted-signing-action/action.yml
@@ -55,7 +55,7 @@ inputs:
 runs:
   using: composite
   steps:
-  - uses: azure/trusted-signing-action@0.4.0
+  - uses: azure/trusted-signing-action@v0.4.0
     with: 
       exclude-environment-credential: false
       exclude-workload-identity-credential: true

--- a/trusted-signing-action/action.yml
+++ b/trusted-signing-action/action.yml
@@ -92,7 +92,7 @@ runs:
       azure-client-secret: ${{ fromJSON(inputs.credentials).client-secret }}
       endpoint: ${{ fromJSON(inputs.credentials).endpoint }}
       trusted-signing-account-name: ${{ fromJSON(inputs.credentials).account-name }}
-      certificate-profile-name: ${{ fromJSON(inputs.use-test-certificate) && "sil-codesign-test" || "sil-codesign-production" }}
+      certificate-profile-name: ${{ (fromJSON(inputs.use-test-certificate) == true) && 'sil-codesign-test' || 'sil-codesign-production' }}
       # Inputs we want to pass through.
       files: ${{ inputs.files }}
       files-folder: ${{ inputs.files-folder }}

--- a/trusted-signing-action/action.yml
+++ b/trusted-signing-action/action.yml
@@ -4,11 +4,9 @@ author: tim-seves
 inputs:
   authentication:
     description: A JSON object containing the credentials to authenticate us to the Trusted Signing Service.
-    default: ${{ secrets.AZURE_TRUSTED_SIGNING_CREDENTIALS }}
     required: false
   account:
     description: A JSON object containing the endpoing, account and certificate identification
-    default: ${{ vars.TRUSTED_SIGNING_CERTIFICATE_ENDPOINT }}
     required: false
   files:
     description: A comma or newline separated list of absolute paths to the files being signed. Can be combined
@@ -58,6 +56,9 @@ runs:
   using: composite
   steps:
   - uses: azure/trusted-signing-action@0.4.0
+    env:
+      AUTH: ${{ inputs.authentication || secrets.AZURE_TRUSTED_SIGNING_CREDENTIALS }}
+      ACCOUNT: ${{ inputs.account || vars.TRUSTED_SIGNING_TEST_CERT}}
     with: 
       exclude-environment-credential: false
       exclude-workload-identity-credential: true
@@ -73,12 +74,12 @@ runs:
       timestamp-rfc3161: http://timestamp.acs.microsoft.com
       timestamp-digest: SHA256
       trace: ${{ runner.debug == '1' }}
-      azure-tenant-id: ${{ fromJSON(inputs.authentication).tenant-id }}
-      azure-client-id: ${{ fromJSON(inputs.authentication).client-id }}
-      azure-client-secret: ${{ fromJSON(inputs.authentication).client-secret }}
-      endpoint: ${{ fromJSON(vars[inputs.account]).endpoint }}
-      trusted-signing-account-name: ${{ fromJSON(inputs.account).account-name }}
-      certificate-profile-name: ${{ fromJSON(inputs.account).profile-name }}
+      azure-tenant-id: ${{ fromJSON(env.AUTH).tenant-id }}
+      azure-client-id: ${{ fromJSON(env.AUTH).client-id }}
+      azure-client-secret: ${{ fromJSON(env.AUTH).client-secret }}
+      endpoint: ${{ fromJSON(env.ACCOUNT).endpoint }}
+      trusted-signing-account-name: ${{ fromJSON(env.ACCOUNT).account-name }}
+      certificate-profile-name: ${{ fromJSON(env.ACCOUNT).profile-name }}
       files: ${{ inputs.files }}
       files-folder: ${{ inputs.files-folder }}
       files-folder-filter: ${{ inputs.files-folder-filter }}

--- a/trusted-signing-action/action.yml
+++ b/trusted-signing-action/action.yml
@@ -1,0 +1,91 @@
+name: Simplified Trusted Signing Action
+description: Sign any Microsoft code or bundle using Microsofts Trusted Signing Service.
+author: tim-seves
+inputs:
+  authentication:
+    description: A JSON object containing the credentials to authenticate us to the Trusted Signing Service.
+    default: ${{ secrets.AZURE_TRUSTED_SIGNING_CREDENTIALS }}
+    required: false
+  account:
+    description: A JSON object containing the endpoing, account and certificate identification
+    default: ${{ vars.TRUSTED_SIGNING_CERTIFICATE_ENDPOINT }}
+    required: false
+  files:
+    description: A comma or newline separated list of absolute paths to the files being signed. Can be combined
+                 with the files-folder and file-catalog inputs.
+    required: false
+  files-folder:
+    description: The folder containing files to be signed. Can be combined with the files and file-catalog inputs.
+    required: false
+  files-folder-filter:
+    description: A comma separated list of file extensions that determines which types of files will
+                 be signed in the folder specified by the files-folder input. E.g., 'dll,exe,msix'.
+                 Any file type not included in this list will not be signed. If this input is not used,
+                 all files in the folder will be signed. Supports wildcards for matching multiple file
+                 names with a pattern.
+    required: false
+  files-folder-recurse:
+    description: A boolean value (true/false) that indicates if the folder specified by the files-folder
+                 input should be searched recursively. The default value is false.
+    required: false
+  files-folder-depth:
+    description: An integer value that indicates the depth of the recursive search toggled by the
+                 files-folder-recursive input.
+    required: false
+  files-catalog:
+    description: A file containing a list of relative paths to the files being signed. The paths
+                 should be relative to the location of the catalog file. Each file path should be on
+                 a separate line. Can be combined with the files and files-folder inputs.
+    required: false
+  description:
+    description: A description of the signed content.
+    required: false
+  description-url:
+    description: A Uniform Resource Locator (URL) for the expanded description of the signed content.
+    required: false
+  timeout:
+    description: The number of seconds that the Trusted Signing service will wait for all files
+                 to be signed before it exits. The default value is 300 seconds.
+    required: false
+  batch-size:
+    description: The summed length of file paths that can be signed with each signtool call. This parameter
+                 should only be relevant if you are signing a large number of files. Increasing the value
+                 may result in performance gains at the risk of potentially hitting your system's maximum
+                 command length limit. The minimum value is 0 and the maximum value is 30000. A value of
+                 0 means that every file will be signed with an individual call to signtool.
+    required: false
+runs:
+  using: composite
+  steps:
+  - uses: azure/trusted-signing-action
+    with: 
+      exclude-environment-credential: false
+      exclude-workload-identity-credential: true
+      exclude-managed-identity-credential: true
+      exclude-shared-token-cache-credential: true
+      exclude-visual-studio-credential: true
+      exclude-visual-studio-code-credential: true
+      exclude-azure-cli-credential: true
+      exclude-azure-powershell-credential: true
+      exclude-azure-developer-cli-credential: true
+      exclude-interactive-browser-credential: true
+      file-digest: SHA256
+      timestamp-rfc3161: http://timestamp.acs.microsoft.com
+      timestamp-digest: SHA256
+      trace: ${{ runner.debug == '1' }}
+      azure-tenant-id: ${{ fromJSON(inputs.authentication).tenant-id }}
+      azure-client-id: ${{ fromJSON(inputs.authentication).client-id }}
+      azure-client-secret: ${{ fromJSON(inputs.authentication).client-secret }}
+      endpoint: ${{ fromJSON(inputs.account).endpoint }}
+      trusted-signing-account-name: ${{ fromJSON(inputs.account).account-name }}
+      certificate-profile-name: ${{ fromJSON(inputs.account).profile-name }}
+      files: ${{ inputs.files }}
+      files-folder: ${{ inputs.files-folder }}
+      files-folder-filter: ${{ inputs.files-folder-filter }}
+      files-folder-recurse: ${{ inputs.files-folder-recurse }}
+      files-folder-depth: ${{ inputs.files-folder-depth }}
+      files-catalog: ${{ inputs.files-catalog }}
+      description: ${{ inputs.description }}
+      description-url: ${{ inputs.description-url }}
+      timeout: ${{ inputs.timeout }}
+      batch-size: ${{ inputs.batch-size }}

--- a/trusted-signing-action/action.yml
+++ b/trusted-signing-action/action.yml
@@ -92,7 +92,7 @@ runs:
       azure-client-secret: ${{ fromJSON(inputs.credentials).client-secret }}
       endpoint: ${{ fromJSON(inputs.credentials).endpoint }}
       trusted-signing-account-name: ${{ fromJSON(inputs.credentials).account-name }}
-      certificate-profile-name: ${{ inputs.certificate-profile-name }}
+      certificate-profile-name: ${{ fromJSON(inputs.use-test-certificate) && "sil-codesign-test" || "sil-codesign-production" }}
       # Inputs we want to pass through.
       files: ${{ inputs.files }}
       files-folder: ${{ inputs.files-folder }}

--- a/trusted-signing-action/action.yml
+++ b/trusted-signing-action/action.yml
@@ -2,12 +2,24 @@ name: Simplified Trusted Signing Action
 description: Sign any Microsoft code or bundle using Microsofts Trusted Signing Service.
 author: tim-seves
 inputs:
-  authentication:
+  # The expected credentials value is a JSON string containing these fields:
+  # {
+  #   "tenant-id": "",
+  #   "client-id": "",
+  #   "client-secret": "",
+  #   "endpoint": "",
+  #   "account-name": ""
+  # }
+  credentials:
     description: A JSON object containing the credentials to authenticate us to the Trusted Signing Service.
     required: false
-  account:
-    description: A JSON object containing the endpoing, account and certificate identification
+  use-test-certificate:
+    description: Use the Public Trust Test certificate for signing. This will allow signing to complete
+                 as normal. However it uses a certificate from an unverifiable root of trust, preventing
+                 test code from being distributed or accidentally uploaded.
     required: false
+    default: 'false'
+  # These are all just passed through verbatim to the azure/trusted-signing-action.
   files:
     description: A comma or newline separated list of absolute paths to the files being signed. Can be combined
                  with the files-folder and file-catalog inputs.
@@ -52,11 +64,16 @@ inputs:
                  command length limit. The minimum value is 0 and the maximum value is 30000. A value of
                  0 means that every file will be signed with an individual call to signtool.
     required: false
+  trace:
+    description: A boolean value (true/false) that controls trace logging. The default value is false.
+    required: false
+    default: ${{ runner.debug == '1' }}
 runs:
   using: composite
   steps:
   - uses: azure/trusted-signing-action@v0.4.0
     with: 
+      # Parameters we want fixed
       exclude-environment-credential: false
       exclude-workload-identity-credential: true
       exclude-managed-identity-credential: true
@@ -70,13 +87,13 @@ runs:
       file-digest: SHA256
       timestamp-rfc3161: http://timestamp.acs.microsoft.com
       timestamp-digest: SHA256
-      trace: ${{ runner.debug == '1' }}
-      azure-tenant-id: ${{ fromJSON(inputs.authentication).tenant-id }}
-      azure-client-id: ${{ fromJSON(inputs.authentication).client-id }}
-      azure-client-secret: ${{ fromJSON(inputs.authentication).client-secret }}
-      endpoint: ${{ fromJSON(inputs.account).endpoint }}
-      trusted-signing-account-name: ${{ fromJSON(inputs.account).account-name }}
-      certificate-profile-name: ${{ fromJSON(inputs.account).profile-name }}
+      azure-tenant-id: ${{ fromJSON(inputs.credentials).tenant-id }}
+      azure-client-id: ${{ fromJSON(inputs.credentials).client-id }}
+      azure-client-secret: ${{ fromJSON(inputs.credentials).client-secret }}
+      endpoint: ${{ fromJSON(inputs.credentials).endpoint }}
+      trusted-signing-account-name: ${{ fromJSON(inputs.credentials).account-name }}
+      certificate-profile-name: ${{ inputs.certificate-profile-name }}
+      # Inputs we want to pass through.
       files: ${{ inputs.files }}
       files-folder: ${{ inputs.files-folder }}
       files-folder-filter: ${{ inputs.files-folder-filter }}
@@ -87,3 +104,4 @@ runs:
       description-url: ${{ inputs.description-url }}
       timeout: ${{ inputs.timeout }}
       batch-size: ${{ inputs.batch-size }}
+      trace: ${{ inputs.trace }}

--- a/trusted-signing-action/action.yml
+++ b/trusted-signing-action/action.yml
@@ -4,11 +4,11 @@ author: tim-seves
 inputs:
   authentication:
     description: A JSON object containing the credentials to authenticate us to the Trusted Signing Service.
-    default: AZURE_TRUSTED_SIGNING_CREDENTIALS
+    default: ${{ secrets.AZURE_TRUSTED_SIGNING_CREDENTIALS }}
     required: false
   account:
     description: A JSON object containing the endpoing, account and certificate identification
-    default: TRUSTED_SIGNING_CERTIFICATE_ENDPOINT
+    default: ${{ vars.TRUSTED_SIGNING_CERTIFICATE_ENDPOINT }}
     required: false
   files:
     description: A comma or newline separated list of absolute paths to the files being signed. Can be combined
@@ -73,12 +73,12 @@ runs:
       timestamp-rfc3161: http://timestamp.acs.microsoft.com
       timestamp-digest: SHA256
       trace: ${{ runner.debug == '1' }}
-      azure-tenant-id: ${{ fromJSON(secrets[inputs.authentication]).tenant-id }}
-      azure-client-id: ${{ fromJSON(secrets[inputs.authentication]).client-id }}
-      azure-client-secret: ${{ fromJSON(secrets[inputs.authentication]).client-secret }}
+      azure-tenant-id: ${{ fromJSON(inputs.authentication).tenant-id }}
+      azure-client-id: ${{ fromJSON(inputs.authentication).client-id }}
+      azure-client-secret: ${{ fromJSON(inputs.authentication).client-secret }}
       endpoint: ${{ fromJSON(vars[inputs.account]).endpoint }}
-      trusted-signing-account-name: ${{ fromJSON(vars[inputs.account]).account-name }}
-      certificate-profile-name: ${{ fromJSON(vars[inputs.account]).profile-name }}
+      trusted-signing-account-name: ${{ fromJSON(inputs.account).account-name }}
+      certificate-profile-name: ${{ fromJSON(inputs.account).profile-name }}
       files: ${{ inputs.files }}
       files-folder: ${{ inputs.files-folder }}
       files-folder-filter: ${{ inputs.files-folder-filter }}

--- a/trusted-signing-action/action.yml
+++ b/trusted-signing-action/action.yml
@@ -71,12 +71,12 @@ runs:
       timestamp-rfc3161: http://timestamp.acs.microsoft.com
       timestamp-digest: SHA256
       trace: ${{ runner.debug == '1' }}
-      azure-tenant-id: ${{ fromJSON(input.authentication).tenant-id }}
-      azure-client-id: ${{ fromJSON(input.authentication).client-id }}
-      azure-client-secret: ${{ fromJSON(input.authentication).client-secret }}
-      endpoint: ${{ fromJSON(input.account).endpoint }}
-      trusted-signing-account-name: ${{ fromJSON(input.account).account-name }}
-      certificate-profile-name: ${{ fromJSON(input.account).profile-name }}
+      azure-tenant-id: ${{ fromJSON(inputs.authentication).tenant-id }}
+      azure-client-id: ${{ fromJSON(inputs.authentication).client-id }}
+      azure-client-secret: ${{ fromJSON(inputs.authentication).client-secret }}
+      endpoint: ${{ fromJSON(inputs.account).endpoint }}
+      trusted-signing-account-name: ${{ fromJSON(inputs.account).account-name }}
+      certificate-profile-name: ${{ fromJSON(inputs.account).profile-name }}
       files: ${{ inputs.files }}
       files-folder: ${{ inputs.files-folder }}
       files-folder-filter: ${{ inputs.files-folder-filter }}

--- a/trusted-signing-action/action.yml
+++ b/trusted-signing-action/action.yml
@@ -16,7 +16,8 @@ inputs:
   use-test-certificate:
     description: Use the Public Trust Test certificate for signing. This will allow signing to complete
                  as normal. However it uses a certificate from an unverifiable root of trust, preventing
-                 test code from being distributed or accidentally uploaded.
+                 test code from being distributed or accidentally uploaded. This defaults to 'false' as 
+                 most of the you will want to be signing with the production certificate.
     required: false
     default: 'false'
   # These are all just passed through verbatim to the azure/trusted-signing-action.

--- a/trusted-signing-action/action.yml
+++ b/trusted-signing-action/action.yml
@@ -56,9 +56,6 @@ runs:
   using: composite
   steps:
   - uses: azure/trusted-signing-action@0.4.0
-    env:
-      AUTH: ${{ inputs.authentication || secrets.AZURE_TRUSTED_SIGNING_CREDENTIALS }}
-      ACCOUNT: ${{ inputs.account || vars.TRUSTED_SIGNING_TEST_CERT}}
     with: 
       exclude-environment-credential: false
       exclude-workload-identity-credential: true
@@ -74,12 +71,12 @@ runs:
       timestamp-rfc3161: http://timestamp.acs.microsoft.com
       timestamp-digest: SHA256
       trace: ${{ runner.debug == '1' }}
-      azure-tenant-id: ${{ fromJSON(env.AUTH).tenant-id }}
-      azure-client-id: ${{ fromJSON(env.AUTH).client-id }}
-      azure-client-secret: ${{ fromJSON(env.AUTH).client-secret }}
-      endpoint: ${{ fromJSON(env.ACCOUNT).endpoint }}
-      trusted-signing-account-name: ${{ fromJSON(env.ACCOUNT).account-name }}
-      certificate-profile-name: ${{ fromJSON(env.ACCOUNT).profile-name }}
+      azure-tenant-id: ${{ fromJSON(input.authentication).tenant-id }}
+      azure-client-id: ${{ fromJSON(input.authentication).client-id }}
+      azure-client-secret: ${{ fromJSON(input.authentication).client-secret }}
+      endpoint: ${{ fromJSON(input.account).endpoint }}
+      trusted-signing-account-name: ${{ fromJSON(input.account).account-name }}
+      certificate-profile-name: ${{ fromJSON(input.account).profile-name }}
       files: ${{ inputs.files }}
       files-folder: ${{ inputs.files-folder }}
       files-folder-filter: ${{ inputs.files-folder-filter }}


### PR DESCRIPTION
This adds an new action which wraps the official azure/trusted-signing-service action and sets some options and tries to make using it a bit more ergonomic in our case.