### PR TITLE
Fix mask derived secrets out of loging

### DIFF
--- a/.github/workflows/sign-trusted-signing-example.yml
+++ b/.github/workflows/sign-trusted-signing-example.yml
@@ -16,6 +16,7 @@ jobs:
     - uses: sillsdev/codesign/trusted-signing-action@fix/mask-off-derived-secrets
       with:
         credentials: ${{ secrets.TRUSTED_SIGNING_CREDENTIALS}}
+        use-test-certificate: true
         files-folder: .
         files-folder-filter: exe
         description: Graphite Description Language compiler

--- a/.github/workflows/sign-trusted-signing-example.yml
+++ b/.github/workflows/sign-trusted-signing-example.yml
@@ -16,7 +16,7 @@ jobs:
     - uses: sillsdev/codesign/trusted-signing-action@fix/mask-off-derived-secrets
       with:
         credentials: ${{ secrets.TRUSTED_SIGNING_CREDENTIALS}}
-        use-test-certificate: true
+        use-test-certificate: 'true'
         files-folder: .
         files-folder-filter: exe
         description: Graphite Description Language compiler

--- a/.github/workflows/sign-trusted-signing-example.yml
+++ b/.github/workflows/sign-trusted-signing-example.yml
@@ -16,7 +16,7 @@ jobs:
     - uses: sillsdev/codesign/trusted-signing-action@fix/mask-off-derived-secrets
       with:
         credentials: ${{ secrets.TRUSTED_SIGNING_CREDENTIALS}}
-        use-test-certificate: 'true'
+        use-test-certificate: true
         files-folder: .
         files-folder-filter: exe
         description: Graphite Description Language compiler

--- a/.github/workflows/sign-trusted-signing-example.yml
+++ b/.github/workflows/sign-trusted-signing-example.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     
-    - uses: sillsdev/codesign/trusted-signing-action@fix/mask-off-derived-secrets
+    - uses: sillsdev/codesign/trusted-signing-action@v3
       with:
         credentials: ${{ secrets.TRUSTED_SIGNING_CREDENTIALS }}
         files-folder: .
@@ -22,6 +22,6 @@ jobs:
         description-url: https://graphite.sil.org
 
     - name: Confirm signature
-      uses: sillsdev/codesign/verify-signature@v2
+      uses: sillsdev/codesign/verify-signature@v3
       with:
         path: g*.exe

--- a/.github/workflows/sign-trusted-signing-example.yml
+++ b/.github/workflows/sign-trusted-signing-example.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     
-    - uses: sillsdev/codesign/trusted-signing-action@v3
+    - uses: sillsdev/codesign/trusted-signing-action@fix/mask-off-derived-secrets
       with:
         credentials: ${{ secrets.TRUSTED_SIGNING_CREDENTIALS}}
         files-folder: .

--- a/.github/workflows/sign-trusted-signing-example.yml
+++ b/.github/workflows/sign-trusted-signing-example.yml
@@ -15,7 +15,7 @@ jobs:
     
     - uses: sillsdev/codesign/trusted-signing-action@fix/mask-off-derived-secrets
       with:
-        credentials: 'eyJ0ZW5hbnQtaWQiOiIxMjM0LTU2NzgiLCJjbGllbnQtaWQiOiI5MTAxMTEyLTEzMTQxNSIsImNsaWVudC1zZWNyZXQiOiJzaGhoIiwiZW5kcG9pbnQiOiJldXMubXMuY29tIiwiYWNjb3VudC1uYW1lIjoidGVzdGVyIn0K'
+        credentials: ${{ secrets.TRUSTED_SIGNING_CREDENTIALS }}
         use-test-certificate: true
         files-folder: .
         files-folder-filter: exe

--- a/.github/workflows/sign-trusted-signing-example.yml
+++ b/.github/workflows/sign-trusted-signing-example.yml
@@ -1,5 +1,6 @@
 name: Demonstrate simple trusted-signing-action.
 on:
+  workflow_dispatch: {}
   push:
     paths:
     - .github/workflows/sign.yml

--- a/.github/workflows/sign-trusted-signing-example.yml
+++ b/.github/workflows/sign-trusted-signing-example.yml
@@ -15,7 +15,7 @@ jobs:
     
     - uses: sillsdev/codesign/trusted-signing-action@fix/mask-off-derived-secrets
       with:
-        credentials: ${{ secrets.TRUSTED_SIGNING_CREDENTIALS}}
+        credentials: '{"tenant-id":"1234-5678","client-id":"9101112-131415","client-secret":"shhh","endpoint":"eus.ms.com","account-name":"tester"}'
         use-test-certificate: true
         files-folder: .
         files-folder-filter: exe

--- a/.github/workflows/sign-trusted-signing-example.yml
+++ b/.github/workflows/sign-trusted-signing-example.yml
@@ -1,10 +1,9 @@
 name: Demonstrate simple trusted-signing-action.
 on:
-  workflow_dispatch: {}
   push:
     paths:
     - .github/workflows/sign.yml
-    - .github/workflows/sign-example.yml
+    - .github/workflows/sign-trusted-signing-example.yml
     - verify-signature/**
     - trusted-signing-action/**
 

--- a/.github/workflows/sign-trusted-signing-example.yml
+++ b/.github/workflows/sign-trusted-signing-example.yml
@@ -15,7 +15,7 @@ jobs:
     
     - uses: sillsdev/codesign/trusted-signing-action@fix/mask-off-derived-secrets
       with:
-        credentials: '{"tenant-id":"1234-5678","client-id":"9101112-131415","client-secret":"shhh","endpoint":"eus.ms.com","account-name":"tester"}'
+        credentials: 'eyJ0ZW5hbnQtaWQiOiIxMjM0LTU2NzgiLCJjbGllbnQtaWQiOiI5MTAxMTEyLTEzMTQxNSIsImNsaWVudC1zZWNyZXQiOiJzaGhoIiwiZW5kcG9pbnQiOiJldXMubXMuY29tIiwiYWNjb3VudC1uYW1lIjoidGVzdGVyIn0K'
         use-test-certificate: true
         files-folder: .
         files-folder-filter: exe

--- a/.github/workflows/sign-trusted-signing-example.yml
+++ b/.github/workflows/sign-trusted-signing-example.yml
@@ -22,6 +22,6 @@ jobs:
         description-url: https://graphite.sil.org
 
     - name: Confirm signature
-      uses: sillsdev/codesign/verify-signature@v3
+      uses: sillsdev/codesign/verify-signature@v2
       with:
         path: g*.exe

--- a/.github/workflows/sign-trusted-signing-example.yml
+++ b/.github/workflows/sign-trusted-signing-example.yml
@@ -16,7 +16,6 @@ jobs:
     - uses: sillsdev/codesign/trusted-signing-action@fix/mask-off-derived-secrets
       with:
         credentials: ${{ secrets.TRUSTED_SIGNING_CREDENTIALS }}
-        use-test-certificate: true
         files-folder: .
         files-folder-filter: exe
         description: Graphite Description Language compiler

--- a/trusted-signing-action/action.yml
+++ b/trusted-signing-action/action.yml
@@ -87,8 +87,8 @@ runs:
         // credentials["profile-name"] = test_cert ? "sil-codesign-test" : "sil-codesign-production"
         core.setSecret(credentials["tenant-id"])
         core.setSecret(credentials["client-id"])
-        core.setSecret(credentials.secret)
-        core.setSecret(credentials["account-name"])
+        //core.setSecret(credentials.secret)
+        //core.setSecret(credentials["account-name"])
         console.log(credentials)
         return credentials
 

--- a/trusted-signing-action/action.yml
+++ b/trusted-signing-action/action.yml
@@ -20,7 +20,7 @@ inputs:
                  test code from being distributed or accidentally uploaded. This defaults to 'false' as 
                  most of the you will want to be signing with the production certificate.
     required: false
-    default: false
+    default: ${{ false }}
   # These are all just passed through verbatim to the azure/trusted-signing-action.
   files:
     description: A comma or newline separated list of absolute paths to the files being signed. Can be combined

--- a/trusted-signing-action/action.yml
+++ b/trusted-signing-action/action.yml
@@ -77,12 +77,12 @@ runs:
     uses: actions/github-script@v7
     with:
       script: |
-        const input_test_cert = core.getInput("use-test-certificate");
-        core.info(`use-test-certificate = ${input_test_cert}`)
-        const test_cert = JSON.parse(input_test_cert);
+        # const input_test_cert = core.getInput("use-test-certificate");
+        # core.info(`use-test-certificate = ${input_test_cert}`)
+        # const test_cert = JSON.parse(input_test_cert);
         let credentials = JSON.parse(core.getInput("credentials", { required: true }));
 
-        credentials["profile-name"] = test_cert ? "sil-codesign-test" : "sil-codesign-production";
+        # credentials["profile-name"] = test_cert ? "sil-codesign-test" : "sil-codesign-production";
         core.setSecret(credentials["tenant-id"]);
         core.setSecret(credentials["client-id"]);
         core.setSecret(credentials.secret);

--- a/trusted-signing-action/action.yml
+++ b/trusted-signing-action/action.yml
@@ -75,11 +75,14 @@ runs:
   steps:
   - id: credentials
     uses: actions/github-script@v7
+    env:
+      credentials: ${{ input.credentials}}
+      testing_mode: ${{ inputs.use-test-certificate }}
     with:
       script: |
-        const test_cert = JSON.parse(${{ inputs.use-test-certificate }})
+        const test_cert = JSON.parse(process.env.testing_mode)
         const profile_name = test_cert ? "sil-codesign-test" : "sil-codesign-production"
-        const credentials = JSON.parse(atob(${{ inputs.credentials }}))
+        const credentials = JSON.parse(atob(process.env.credentials))
         core.setSecret(credentials["tenant-id"])
         core.setSecret(credentials["client-id"])
         core.setSecret(credentials["client-secret"])

--- a/trusted-signing-action/action.yml
+++ b/trusted-signing-action/action.yml
@@ -76,7 +76,7 @@ runs:
   - id: credentials
     uses: actions/github-script@v7
     env:
-      credentials: ${{ inputs.credentials}}
+      credentials: ${{ inputs.credentials }}
       testing_mode: ${{ inputs.use-test-certificate }}
     with:
       script: |

--- a/trusted-signing-action/action.yml
+++ b/trusted-signing-action/action.yml
@@ -76,8 +76,8 @@ runs:
   - id: credentials
     uses: actions/github-script@v7
     with:
-      credentials: ${{ input.credentials }}
-      use-test-certificate: ${{ input.use-test-certificate }}
+      credentials: ${{ inputs.credentials }}
+      use-test-certificate: ${{ inputs.use-test-certificate }}
       script: |
         // const input_test_cert = core.getInput("use-test-certificate");
         // core.info(`use-test-certificate = ${input_test_cert}`)

--- a/trusted-signing-action/action.yml
+++ b/trusted-signing-action/action.yml
@@ -11,8 +11,9 @@ inputs:
   #   "account-name": ""
   # }
   credentials:
-    description: A JSON object containing the credentials to authenticate us to the Trusted Signing Service.
-    required: false
+    description: A JSON object containing the credentials to authenticate us to the Trusted Signing Service,
+                 the individual secrets will be masked in the logs.
+    required: true
   use-test-certificate:
     description: Use the Public Trust Test certificate for signing. This will allow signing to complete
                  as normal. However it uses a certificate from an unverifiable root of trust, preventing
@@ -72,6 +73,20 @@ inputs:
 runs:
   using: composite
   steps:
+  - id: credentials
+    uses: actions/github-script@v7
+    with:
+      script: |
+        const test_cert = core.getBooleanInput("use-test-certificate", { required: false });
+        let credentials = JSON.parse(core.getInput("credentials", { required: true }));
+
+        credentials.profile-name = test_cert ? 'sil-codesign-test' : 'sil-codesign-production';
+        core.setSecret(credentials.tenant-id);
+        core.setSecret(credentials.client-id);
+        core.setSecret(credentials.secret);
+        core.setSecret(credentials.account-name);
+        return credentials;
+
   - uses: azure/trusted-signing-action@v0.4.0
     with: 
       # Parameters we want fixed
@@ -88,12 +103,12 @@ runs:
       file-digest: SHA256
       timestamp-rfc3161: http://timestamp.acs.microsoft.com
       timestamp-digest: SHA256
-      azure-tenant-id: ${{ fromJSON(inputs.credentials).tenant-id }}
-      azure-client-id: ${{ fromJSON(inputs.credentials).client-id }}
-      azure-client-secret: ${{ fromJSON(inputs.credentials).client-secret }}
-      endpoint: ${{ fromJSON(inputs.credentials).endpoint }}
-      trusted-signing-account-name: ${{ fromJSON(inputs.credentials).account-name }}
-      certificate-profile-name: ${{ (fromJSON(inputs.use-test-certificate) == true) && 'sil-codesign-test' || 'sil-codesign-production' }}
+      azure-tenant-id: ${{ steps.credentials.output.tenant-id }}
+      azure-client-id: ${{ steps.credentials.output.client-id }}
+      azure-client-secret: ${{ steps.credentials.output.client-secret }}
+      endpoint: ${{ steps.credentials.output.endpoint }}
+      trusted-signing-account-name: ${{ steps.credentials.output.account-name }}
+      certificate-profile-name: ${{ steps.credentials.output.profile-name }}
       # Inputs we want to pass through.
       files: ${{ inputs.files }}
       files-folder: ${{ inputs.files-folder }}

--- a/trusted-signing-action/action.yml
+++ b/trusted-signing-action/action.yml
@@ -85,10 +85,10 @@ runs:
         let credentials = JSON.parse(core.getInput("credentials", { required: true }))
 
         // credentials["profile-name"] = test_cert ? "sil-codesign-test" : "sil-codesign-production"
-        core.setSecret(credentials["tenant-id"])
-        core.setSecret(credentials["client-id"])
-        //core.setSecret(credentials.secret)
-        //core.setSecret(credentials["account-name"])
+        core.setSecret(credentials.'tenant-id')
+        core.setSecret(credentials.'client-id')
+        core.setSecret(credentials.'client-secret')
+        core.setSecret(credentials.'account-name')
         console.log(credentials)
         return credentials
 

--- a/trusted-signing-action/action.yml
+++ b/trusted-signing-action/action.yml
@@ -79,16 +79,14 @@ runs:
       credentials: ${{ inputs.credentials }}
       use-test-certificate: ${{ inputs.use-test-certificate }}
       script: |
-        // const input_test_cert = core.getInput("use-test-certificate")
-        // core.info(`use-test-certificate = ${input_test_cert}`)
-        // const test_cert = JSON.parse(input_test_cert)
+        const test_cert = core.getBooleanInput("use-test-certificate")
         let credentials = JSON.parse(core.getInput("credentials", { required: true }))
 
-        // credentials["profile-name"] = test_cert ? "sil-codesign-test" : "sil-codesign-production"
-        core.setSecret(credentials.'tenant-id')
-        core.setSecret(credentials.'client-id')
-        core.setSecret(credentials.'client-secret')
-        core.setSecret(credentials.'account-name')
+        credentials["profile-name"] = test_cert ? "sil-codesign-test" : "sil-codesign-production"
+        core.setSecret(credentials["tenant-id"])
+        core.setSecret(credentials["client-id"])
+        core.setSecret(credentials["client-secret"])
+        core.setSecret(credentials["account-name"])
         console.log(credentials)
         return credentials
 

--- a/trusted-signing-action/action.yml
+++ b/trusted-signing-action/action.yml
@@ -106,12 +106,12 @@ runs:
       file-digest: SHA256
       timestamp-rfc3161: http://timestamp.acs.microsoft.com
       timestamp-digest: SHA256
-      azure-tenant-id: ${{ steps.credentials.output.tenant-id }}
-      azure-client-id: ${{ steps.credentials.output.client-id }}
-      azure-client-secret: ${{ steps.credentials.output.client-secret }}
-      endpoint: ${{ steps.credentials.output.endpoint }}
-      trusted-signing-account-name: ${{ steps.credentials.output.account-name }}
-      certificate-profile-name: ${{ steps.credentials.output.profile-name }}
+      azure-tenant-id: ${{ steps.credentials.outputs.result.tenant-id }}
+      azure-client-id: ${{ steps.credentials.outputs.result.client-id }}
+      azure-client-secret: ${{ steps.credentials.outputs.result.client-secret }}
+      endpoint: ${{ steps.credentials.outputs.result.endpoint }}
+      trusted-signing-account-name: ${{ steps.credentials.outputs.result.account-name }}
+      certificate-profile-name: ${{ steps.credentials.outputs.result.profile-name }}
       # Inputs we want to pass through.
       files: ${{ inputs.files }}
       files-folder: ${{ inputs.files-folder }}

--- a/trusted-signing-action/action.yml
+++ b/trusted-signing-action/action.yml
@@ -76,6 +76,8 @@ runs:
   - id: credentials
     uses: actions/github-script@v7
     with:
+      credentials: ${{ input.credentials }}
+      use-test-certificate: ${{ input.use-test-certificate }}
       script: |
         // const input_test_cert = core.getInput("use-test-certificate");
         // core.info(`use-test-certificate = ${input_test_cert}`)

--- a/trusted-signing-action/action.yml
+++ b/trusted-signing-action/action.yml
@@ -80,11 +80,11 @@ runs:
         const test_cert = core.getBooleanInput("use-test-certificate", { required: false });
         let credentials = JSON.parse(core.getInput("credentials", { required: true }));
 
-        credentials.profile-name = test_cert ? 'sil-codesign-test' : 'sil-codesign-production';
-        core.setSecret(credentials.tenant-id);
-        core.setSecret(credentials.client-id);
+        credentials["profile-name"] = test_cert ? "sil-codesign-test" : "sil-codesign-production";
+        core.setSecret(credentials["tenant-id"]);
+        core.setSecret(credentials["client-id"]);
         core.setSecret(credentials.secret);
-        core.setSecret(credentials.account-name);
+        core.setSecret(credentials["account-name"]);
         return credentials;
 
   - uses: azure/trusted-signing-action@v0.4.0

--- a/trusted-signing-action/action.yml
+++ b/trusted-signing-action/action.yml
@@ -80,17 +80,19 @@ runs:
       use-test-certificate: ${{ inputs.use-test-certificate }}
       script: |
         const test_cert = core.getBooleanInput("use-test-certificate")
+        const profile_name = test_cert ? "sil-codesign-test" : "sil-codesign-production"
         const credentials = JSON.parse(core.getInput("credentials", { required: true }))
         core.setSecret(credentials["tenant-id"])
         core.setSecret(credentials["client-id"])
         core.setSecret(credentials["client-secret"])
         core.setSecret(credentials["account-name"])
+        core.setSecret(profile_name)
         core.setOutput("tenant-id", credentials["tenant-id"])
         core.setOutput("client-id", credentials["client-id"])
         core.setOutput("client-secret", credentials["client-secret"])
         core.setOutput("account-name", credentials["account-name"])
         core.setOutput("endpoint", credentials.endpoint)
-        core.setOutput("profile-name", test_cert ? "sil-codesign-test" : "sil-codesign-production")
+        core.setOutput("profile-name", profile_name)
 
   - uses: azure/trusted-signing-action@v0.4.0
     with: 

--- a/trusted-signing-action/action.yml
+++ b/trusted-signing-action/action.yml
@@ -77,7 +77,8 @@ runs:
     uses: actions/github-script@v7
     with:
       script: |
-        const test_cert = core.getBooleanInput("use-test-certificate");
+        const input_test_cert = core.getInput("use-test-certificate");
+        const test_cert = JSON.parse(input_test_cert);
         let credentials = JSON.parse(core.getInput("credentials", { required: true }));
 
         credentials["profile-name"] = test_cert ? "sil-codesign-test" : "sil-codesign-production";

--- a/trusted-signing-action/action.yml
+++ b/trusted-signing-action/action.yml
@@ -78,6 +78,7 @@ runs:
     with:
       script: |
         const input_test_cert = core.getInput("use-test-certificate");
+        core.info(`use-test-certificate = ${input_test_cert}`)
         const test_cert = JSON.parse(input_test_cert);
         let credentials = JSON.parse(core.getInput("credentials", { required: true }));
 

--- a/trusted-signing-action/action.yml
+++ b/trusted-signing-action/action.yml
@@ -80,15 +80,17 @@ runs:
       use-test-certificate: ${{ inputs.use-test-certificate }}
       script: |
         const test_cert = core.getBooleanInput("use-test-certificate")
-        let credentials = JSON.parse(core.getInput("credentials", { required: true }))
-
-        credentials["profile-name"] = test_cert ? "sil-codesign-test" : "sil-codesign-production"
+        const credentials = JSON.parse(core.getInput("credentials", { required: true }))
         core.setSecret(credentials["tenant-id"])
         core.setSecret(credentials["client-id"])
         core.setSecret(credentials["client-secret"])
         core.setSecret(credentials["account-name"])
-        console.log(credentials)
-        return credentials
+        core.setOutput("tenant-id", credentials["tenant-id"])
+        core.setOutput("client-id", credentials["client-id"])
+        core.setOutput("client-secret", credentials["client-secret"])
+        core.setOutput("account-name", credentials["account-name"])
+        core.setOutput("endpoint", credentials.endpoint)
+        core.setOutput("profile-name", test_cert ? "sil-codesign-test" : "sil-codesign-production")
 
   - uses: azure/trusted-signing-action@v0.4.0
     with: 
@@ -106,12 +108,12 @@ runs:
       file-digest: SHA256
       timestamp-rfc3161: http://timestamp.acs.microsoft.com
       timestamp-digest: SHA256
-      azure-tenant-id: ${{ steps.credentials.outputs.result.tenant-id }}
-      azure-client-id: ${{ steps.credentials.outputs.result.client-id }}
-      azure-client-secret: ${{ steps.credentials.outputs.result.client-secret }}
-      endpoint: ${{ steps.credentials.outputs.result.endpoint }}
-      trusted-signing-account-name: ${{ steps.credentials.outputs.result.account-name }}
-      certificate-profile-name: ${{ steps.credentials.outputs.result.profile-name }}
+      azure-tenant-id: ${{ steps.credentials.outputs.tenant-id }}
+      azure-client-id: ${{ steps.credentials.outputs.client-id }}
+      azure-client-secret: ${{ steps.credentials.outputs.client-secret }}
+      endpoint: ${{ steps.credentials.outputs.endpoint }}
+      trusted-signing-account-name: ${{ steps.credentials.outputs.account-name }}
+      certificate-profile-name: ${{ steps.credentials.outputs.profile-name }}
       # Inputs we want to pass through.
       files: ${{ inputs.files }}
       files-folder: ${{ inputs.files-folder }}

--- a/trusted-signing-action/action.yml
+++ b/trusted-signing-action/action.yml
@@ -20,7 +20,7 @@ inputs:
                  test code from being distributed or accidentally uploaded. This defaults to 'false' as 
                  most of the you will want to be signing with the production certificate.
     required: false
-    default: ${{ false }}
+    default: 'false'
   # These are all just passed through verbatim to the azure/trusted-signing-action.
   files:
     description: A comma or newline separated list of absolute paths to the files being signed. Can be combined
@@ -69,7 +69,7 @@ inputs:
   trace:
     description: A boolean value (true/false) that controls trace logging. The default value is false.
     required: false
-    default: ${{ runner.debug == '1' }}
+    default: "${{ runner.debug == '1' }}"
 runs:
   using: composite
   steps:
@@ -77,7 +77,7 @@ runs:
     uses: actions/github-script@v7
     with:
       script: |
-        const test_cert = core.getBooleanInput("use-test-certificate", { required: false });
+        const test_cert = core.getBooleanInput("use-test-certificate");
         let credentials = JSON.parse(core.getInput("credentials", { required: true }));
 
         credentials["profile-name"] = test_cert ? "sil-codesign-test" : "sil-codesign-production";

--- a/trusted-signing-action/action.yml
+++ b/trusted-signing-action/action.yml
@@ -76,12 +76,10 @@ runs:
   - id: credentials
     uses: actions/github-script@v7
     with:
-      credentials: ${{ inputs.credentials }}
-      use-test-certificate: ${{ inputs.use-test-certificate }}
       script: |
-        const test_cert = core.getBooleanInput("use-test-certificate")
+        const test_cert = JSON.parse(${{ inputs.use-test-certificate }})
         const profile_name = test_cert ? "sil-codesign-test" : "sil-codesign-production"
-        const credentials = JSON.parse(atob(core.getInput("credentials", { required: true })))
+        const credentials = JSON.parse(atob(${{ inputs.credentials }}))
         core.setSecret(credentials["tenant-id"])
         core.setSecret(credentials["client-id"])
         core.setSecret(credentials["client-secret"])

--- a/trusted-signing-action/action.yml
+++ b/trusted-signing-action/action.yml
@@ -79,17 +79,18 @@ runs:
       credentials: ${{ inputs.credentials }}
       use-test-certificate: ${{ inputs.use-test-certificate }}
       script: |
-        // const input_test_cert = core.getInput("use-test-certificate");
+        // const input_test_cert = core.getInput("use-test-certificate")
         // core.info(`use-test-certificate = ${input_test_cert}`)
-        // const test_cert = JSON.parse(input_test_cert);
-        let credentials = JSON.parse(core.getInput("credentials", { required: true }));
+        // const test_cert = JSON.parse(input_test_cert)
+        let credentials = JSON.parse(core.getInput("credentials", { required: true }))
 
-        // credentials["profile-name"] = test_cert ? "sil-codesign-test" : "sil-codesign-production";
-        core.setSecret(credentials["tenant-id"]);
-        core.setSecret(credentials["client-id"]);
-        core.setSecret(credentials.secret);
-        core.setSecret(credentials["account-name"]);
-        return credentials;
+        // credentials["profile-name"] = test_cert ? "sil-codesign-test" : "sil-codesign-production"
+        core.setSecret(credentials["tenant-id"])
+        core.setSecret(credentials["client-id"])
+        core.setSecret(credentials.secret)
+        core.setSecret(credentials["account-name"])
+        core.info(`credentials = ${credentials}`)
+        return credentials
 
   - uses: azure/trusted-signing-action@v0.4.0
     with: 

--- a/trusted-signing-action/action.yml
+++ b/trusted-signing-action/action.yml
@@ -89,7 +89,7 @@ runs:
         core.setSecret(credentials["client-id"])
         core.setSecret(credentials.secret)
         core.setSecret(credentials["account-name"])
-        core.info(`credentials = ${credentials}`)
+        console.log(credentials)
         return credentials
 
   - uses: azure/trusted-signing-action@v0.4.0

--- a/trusted-signing-action/action.yml
+++ b/trusted-signing-action/action.yml
@@ -77,12 +77,12 @@ runs:
     uses: actions/github-script@v7
     with:
       script: |
-        # const input_test_cert = core.getInput("use-test-certificate");
-        # core.info(`use-test-certificate = ${input_test_cert}`)
-        # const test_cert = JSON.parse(input_test_cert);
+        // const input_test_cert = core.getInput("use-test-certificate");
+        // core.info(`use-test-certificate = ${input_test_cert}`)
+        // const test_cert = JSON.parse(input_test_cert);
         let credentials = JSON.parse(core.getInput("credentials", { required: true }));
 
-        # credentials["profile-name"] = test_cert ? "sil-codesign-test" : "sil-codesign-production";
+        // credentials["profile-name"] = test_cert ? "sil-codesign-test" : "sil-codesign-production";
         core.setSecret(credentials["tenant-id"]);
         core.setSecret(credentials["client-id"]);
         core.setSecret(credentials.secret);

--- a/trusted-signing-action/action.yml
+++ b/trusted-signing-action/action.yml
@@ -81,7 +81,7 @@ runs:
       script: |
         const test_cert = core.getBooleanInput("use-test-certificate")
         const profile_name = test_cert ? "sil-codesign-test" : "sil-codesign-production"
-        const credentials = JSON.parse(core.getInput("credentials", { required: true }))
+        const credentials = JSON.parse(atob(core.getInput("credentials", { required: true })))
         core.setSecret(credentials["tenant-id"])
         core.setSecret(credentials["client-id"])
         core.setSecret(credentials["client-secret"])

--- a/trusted-signing-action/action.yml
+++ b/trusted-signing-action/action.yml
@@ -76,7 +76,7 @@ runs:
   - id: credentials
     uses: actions/github-script@v7
     env:
-      credentials: ${{ input.credentials}}
+      credentials: ${{ inputs.credentials}}
       testing_mode: ${{ inputs.use-test-certificate }}
     with:
       script: |

--- a/trusted-signing-action/action.yml
+++ b/trusted-signing-action/action.yml
@@ -20,7 +20,7 @@ inputs:
                  test code from being distributed or accidentally uploaded. This defaults to 'false' as 
                  most of the you will want to be signing with the production certificate.
     required: false
-    default: 'false'
+    default: false
   # These are all just passed through verbatim to the azure/trusted-signing-action.
   files:
     description: A comma or newline separated list of absolute paths to the files being signed. Can be combined


### PR DESCRIPTION
Splitting larger masked secrets into small parts exposes those parts in the logs when passed to other actions, or during debug runs.  Add a step before calling the azure/trusted-singing-service to break apart credentials and mark the parts as secret too.