### PR TITLE
Split README into current an deprecated versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # Codesign <br/> [![sign.yml reusable workflow.](https://github.com/sillsdev/codesign/actions/workflows/sign-example.yml/badge.svg)](https://github.com/sillsdev/codesign/actions/workflows/sign-example.yml) [![Demonstrate simple trusted-signing-action.](https://github.com/sillsdev/codesign/actions/workflows/sign-trusted-signing-example.yml/badge.svg)](https://github.com/sillsdev/codesign/actions/workflows/sign-trusted-signing-example.yml)
 
-This contains a facade action to Microsofts [azure/trusted-signing-action](https://github.com/Azure/trusted-signing-action), which takes care of setting required presets, and hides of the many account and authentication parameters in a secret JSON bundle. This action passes through all other parameters for selecting files to sign, and specifying descriptions. It reduces the `certificate-profile-name` input to a binary choice between our production and non-validating test certs.
+This repo provides a facade action over Microsoft's [azure/trusted-signing-action](https://github.com/Azure/trusted-signing-action). This Action takes care of setting required presets, and hides the many account and authentication parameters behind a secret JSON bundle. It also passes through all other parameters for selecting files, and specifying descriptions, and will select the right `certificate-profile-name` input based on a testing flag.
 
-Please see further down for the documentation for the original [v2 documentation](#Deprecated-v2-Actions-and-Workflow-documentation)
+Please see further down for the documentation for the original [v2 documentation](/sillsdev/codesign/README.v2.md)
 
 
 ## Runner requirements
 
-All the actions in the repo will only run on a windows runner, the GitHub hosted windows runner will work as will self-hosted runners with Windows 7+ which have Powershell 5.1+, and .NET runtime 6.0+
+All the actions in the repo will only run on a windows runner, the GitHub hosted windows runner will work, as will self-hosted runners with Windows 7+ which have Powershell 5.1+, and .NET runtime 6.0+
 
 ## Example
 
@@ -32,7 +32,7 @@ These are the specific inputs for the `sillsdev/codesign/trusted-signing-action`
 
 ### Authentication
 
-This Action connects to the Azure service via OpenID Connect only we don't support any of the other authentication mechanisms. All the account and authentication parameters are supplied via a secret JSON bundle defined like so:
+This Action connects to the Azure service via OpenID Connect only, we do not support any of the other authentication mechanisms. All the account and authentication parameters are supplied via a secret JSON bundle defined like so, and base64 encoded:
 ```json
 {
   "tenant-id": "<Entra Directory ID>",
@@ -48,10 +48,10 @@ We provide this bundle as an Organizational secret visible to selected repos cal
 ```yaml
 use-test-certificate: true
 ```
-Don't use the Public Trust production certificate, instead use the Public Trust Test cert. This is guarenteed not validate. Defaults to 'false'.
+Tells the signing service to use our Public Trust Test certificate, instead of the production certificate. This certificate is guarenteed not validate. Defaults to 'false'.
 
 
-## Azure action parameters
+## `azure/trusted-signing-action` parameters
 ### Supported
 We pass the following inputs through verbatim:
 * `files`
@@ -64,7 +64,7 @@ We pass the following inputs through verbatim:
 * `description-url`
 * `timeout`
 * `batch-size`
-* `trace` except if the runner is debug mode, then it is always on
+* `trace` except if the runner is debug mode, then it is always on.
 
 ### Unsupported
 The following parameters from the Azure Action are not accepted as they are supplied by, or superceded by this Actions `credentials` parameter:
@@ -76,36 +76,9 @@ The following parameters from the Azure Action are not accepted as they are supp
 * `endpoint`
 * `trusted-signing-account-name`
 
-The following Azure parameters predefined by this Action, and so not accepted:
+The following Azure parameters preset by this Action, and so not accepted as inputs:
 * `certificate-profile-name` derived from `use-test-certificate`
-* `file-digest` set to SHA256
-* `timestamp-rfc3161` always uses http://timestamp.acs.microsoft.com
-* `timestamp-digest` set to SHA256
-* all `exclude-*-credential` inputs
-
-
-
-# Deprecated v2 Actions and Workflow documentation
-The repo also contains the now deprecated front end reusable workflow `sign.yml`, and the actions and subworkflow that implement it along with tests/examples showing how to use them. These are effectively halting development and v2.1.
-
-The simplest interface is the `sillsdev/codesign/.github/workflows/sign.yml` reusable workflow. This allows the signing of a multiple files, by calling into `sillsdev/codesign/.github/workflows/sign-digest.yml` to pass the detached digest for signing on our in-house code signing system. Files to be signed must be passed in an artifact, which will be overwritten with the signed versions when the `sign-digest.yml` workflow completes.
-
-There are a several actions that facilitate more integrapted use of sign-digest.yml, by removing the need to pass files eclusively via artifacts. These break out the phases into windows only actions, permiting integration of the generate, apply, timestamp and verify phases into existing workflows where convenient. These are:
-
-1. `sillsdev/codesign/generate-digest`: Generates a job to be passed to the `sign-digest.yml`, creating a temporary artifact to hold intermediate state.
-2. `sillsdev/codesign/.github/workflows/sign-digest.yml`: Communicates with our remote signer, and provides a signed-digest job to be used in the signature attachment phase.
-3. `sillsdev/codesign/apply-signed-digest`: Completes the signing process using the job from `workflow/sign-digest.yml`, by attaching the signed-digests to the files, deletes the temporay artifact, and then places the signed files into an optional directory (creating it as necessary), or into the workspace directory otherwise.
-4. `sillsdev/codesign/timestamp`: Given correctly signed files attaches a secure timetamp, retying as necessary upto 10 times.
-5. `sillsdev/codesign/verify-signature`: A simple way to test if files have a valid signature.
-
-The generate-digest, timestamp, and verify-signature actions take a `path:` parameter that works the same way as `actions/upload-artifact`'s `path:` parameter, allowing you to specify files using a set of globs or filenames, one per line. e.g.:
-```yaml
-      uses: sillsdev/codesign/generate-digest@v2
-      with:
-        path: |
-          gdlpp.exe
-          grcompiler.exe
-          *.dll
-```
-
-Please see the test files [sign-example.yml](https://github.com/sillsdev/codesign/blob/main/.github/workflows/sign-example.yml), and [actions-example.yml](https://github.com/sillsdev/codesign/blob/main/.github/workflows/actions-example.yml), for examples of how to use these resources.
+* `file-digest` set to SHA256.
+* `timestamp-rfc3161` always uses http://timestamp.acs.microsoft.com.
+* `timestamp-digest` set to SHA256.
+* all `exclude-*-credential` inputs as we only support one authentication mechanism.

--- a/README.v2.md
+++ b/README.v2.md
@@ -1,0 +1,25 @@
+# Codesign [![sign.yml reusable workflow.](https://github.com/sillsdev/codesign/actions/workflows/sign-example.yml/badge.svg)](https://github.com/sillsdev/codesign/actions/workflows/sign-example.yml)
+
+The repo also contains the now deprecated front end reusable workflow `sign.yml`, and the actions and subworkflow that implement it along with tests/examples showing how to use them. These are effectively halting development at v2.1.
+
+The simplest interface is the `sillsdev/codesign/.github/workflows/sign.yml` reusable workflow. This allows the signing of a multiple files, by calling into `sillsdev/codesign/.github/workflows/sign-digest.yml` to pass the detached digest for signing on our in-house code signing system. Files to be signed must be passed in an artifact, which will be overwritten with the signed versions when the `sign-digest.yml` workflow completes.
+
+There are a several actions that facilitate more integrapted use of sign-digest.yml, by removing the need to pass files eclusively via artifacts. These break out the phases into windows only actions, permiting integration of the generate, apply, timestamp and verify phases into existing workflows where convenient. These are:
+
+1. `sillsdev/codesign/generate-digest`: Generates a job to be passed to the `sign-digest.yml`, creating a temporary artifact to hold intermediate state.
+2. `sillsdev/codesign/.github/workflows/sign-digest.yml`: Communicates with our remote signer, and provides a signed-digest job to be used in the signature attachment phase.
+3. `sillsdev/codesign/apply-signed-digest`: Completes the signing process using the job from `workflow/sign-digest.yml`, by attaching the signed-digests to the files, deletes the temporay artifact, and then places the signed files into an optional directory (creating it as necessary), or into the workspace directory otherwise.
+4. `sillsdev/codesign/timestamp`: Given correctly signed files attaches a secure timetamp, retying as necessary upto 10 times.
+5. `sillsdev/codesign/verify-signature`: A simple way to test if files have a valid signature.
+
+The generate-digest, timestamp, and verify-signature actions take a `path:` parameter that works the same way as `actions/upload-artifact`'s `path:` parameter, allowing you to specify files using a set of globs or filenames, one per line. e.g.:
+```yaml
+      uses: sillsdev/codesign/generate-digest@v2
+      with:
+        path: |
+          gdlpp.exe
+          grcompiler.exe
+          *.dll
+```
+
+Please see the test files [sign-example.yml](https://github.com/sillsdev/codesign/blob/main/.github/workflows/sign-example.yml), and [actions-example.yml](https://github.com/sillsdev/codesign/blob/main/.github/workflows/actions-example.yml), for examples of how to use these resources.


### PR DESCRIPTION
Move the older documentation to it's own README and link to that from the primary. Fix spelling and grammatical errors.
Improve some phrasing.