### PR TITLE
Update version of azure/trusted-signing-action used

### DIFF
--- a/trusted-signing-action/action.yml
+++ b/trusted-signing-action/action.yml
@@ -110,7 +110,7 @@ runs:
         core.setOutput("endpoint", credentials.endpoint)
         core.setOutput("profile-name", profile_name)
 
-  - uses: azure/trusted-signing-action@v0.4.0
+  - uses: azure/trusted-signing-action@v0.5.1
     with: 
       # Parameters we want fixed
       exclude-environment-credential: false


### PR DESCRIPTION
Move us to version 0.5 of the azure supplied action we wrap.