### PR TITLE
Update old digest signer to run on the new signing gh-runner

### DIFF
--- a/.github/workflows/actions-example.yml
+++ b/.github/workflows/actions-example.yml
@@ -2,8 +2,8 @@ name: Demonstrate use of fine grained actions with sign-digest.yml workflow
 on:
   push:
     paths:
-    - .github/workflows/sign-digest.yml
     - .github/workflows/actions-example.yml
+    - .github/workflows/sign-digest.yml
     - apply-signed-digest/**
     - generate-digest/**
     - timestamp/**

--- a/.github/workflows/actions-example.yml
+++ b/.github/workflows/actions-example.yml
@@ -33,7 +33,7 @@ jobs:
 
   sign:
     needs: build
-    uses: sillsdev/codesign/.github/workflows/sign-digest.yml@v2
+    uses: sillsdev/codesign/.github/workflows/sign-digest.yml@fix/switch-to-new-gh-runner
     with:
       job: ${{ needs.build.outputs.job1 }}
   

--- a/.github/workflows/actions-example.yml
+++ b/.github/workflows/actions-example.yml
@@ -33,7 +33,7 @@ jobs:
 
   sign:
     needs: build
-    uses: sillsdev/codesign/.github/workflows/sign-digest.yml@fix/switch-to-new-gh-runner
+    uses: sillsdev/codesign/.github/workflows/sign-digest.yml@v2.1
     with:
       job: ${{ needs.build.outputs.job1 }}
   

--- a/.github/workflows/sign-digest.yml
+++ b/.github/workflows/sign-digest.yml
@@ -29,7 +29,7 @@ jobs:
   sign-digest:
     outputs:
       job: ${{ inputs.job }}
-    runs-on: [self-hosted, ltops-signing]
+    runs-on: [self-hosted, techops-signing]
     steps:
     - uses: actions/download-artifact@v4
       with:

--- a/.github/workflows/sign-example.yml
+++ b/.github/workflows/sign-example.yml
@@ -24,7 +24,7 @@ jobs:
 
   sign:
     needs: build
-    uses: sillsdev/codesign/.github/workflows/sign.yml@fix/switch-to-new-gh-runner
+    uses: sillsdev/codesign/.github/workflows/sign.yml@v2.1
     with:
       artifact: grcompiler
       description: Graphite

--- a/.github/workflows/sign-example.yml
+++ b/.github/workflows/sign-example.yml
@@ -23,7 +23,7 @@ jobs:
 
   sign:
     needs: build
-    uses: sillsdev/codesign/.github/workflows/sign.yml@v2.1
+    uses: sillsdev/codesign/.github/workflows/sign.yml@fix/switch-to-new-gh-runner
     with:
       artifact: grcompiler
       description: Graphite

--- a/.github/workflows/sign-example.yml
+++ b/.github/workflows/sign-example.yml
@@ -3,6 +3,7 @@ on:
   push:
     paths:
     - .github/workflows/sign.yml
+    - .github/workflows/sign-digest.yml
     - .github/workflows/sign-example.yml
     - apply-signed-digest/**
     - generate-digest/**

--- a/.github/workflows/sign-trusted-signing-example.yml
+++ b/.github/workflows/sign-trusted-signing-example.yml
@@ -2,7 +2,6 @@ name: Demonstrate simple trusted-signing-action.
 on:
   push:
     paths:
-    - .github/workflows/sign.yml
     - .github/workflows/sign-trusted-signing-example.yml
     - verify-signature/**
     - trusted-signing-action/**

--- a/.github/workflows/sign.yml
+++ b/.github/workflows/sign.yml
@@ -46,7 +46,7 @@ jobs:
 
   remotesign:
     needs: digest
-    uses: sillsdev/codesign/.github/workflows/sign-digest.yml@v2.1
+    uses: sillsdev/codesign/.github/workflows/sign-digest.yml@fix/switch-to-new-gh-runner
     with:
       job: ${{ needs.digest.outputs.job }}
    

--- a/.github/workflows/sign.yml
+++ b/.github/workflows/sign.yml
@@ -46,7 +46,7 @@ jobs:
 
   remotesign:
     needs: digest
-    uses: sillsdev/codesign/.github/workflows/sign-digest.yml@fix/switch-to-new-gh-runner
+    uses: sillsdev/codesign/.github/workflows/sign-digest.yml@v2.1
     with:
       job: ${{ needs.digest.outputs.job }}
    

--- a/.github/workflows/test-sign-digest.yml
+++ b/.github/workflows/test-sign-digest.yml
@@ -2,8 +2,9 @@ name: Test communication
 on:
   push:
     paths:
-    - .github/workflows/sign-digest.yml
     - .github/workflows/test-sign-digest.yml
+    - .github/workflows/sign-digest.yml
+    
 env:
   DIGEST: egf6ayf/Osfooq7xfsR5SjjvbGdMXVbtQZKe0aR8djQ=
   SIGNED_DIGEST: "Z+kPJkMX7Iu0uhmsOKSwxHUvMsUVGH3wVoEC7ZJaUw6XIM8WmpqXX66FIqyLWkMLTP5Qd4Iyh/ODx5rSWIWBavoR3je7GPDjM2nigfdZu3wwiu2SJS0ITgB9JsG5sBShNe1pySik1vCkAHdjz+akgoE5+sGikzHm4cpB4tgBqVSvehSgJeTGLJpiBJWD+KfpMrYJ7wxOam4n/gp2vOKcrGiV9kPWnT0eVsFJJzTHe0vI7jLgWZVog5ECDZyLRC/tKWWbdt0ZwehmRKRBPwnLMKjNHeOvavwZiex5ImJifD0CKvEzEh78iMwNTbIe1vBjdF/XAvlq1OB6r8q5wQKQkXAkDaokmBvzpXC8mxqK/r++gyR3qdu9Uzk9/5qA3BPT5IMsYBtjr6XlVQ4jeQAY8mN8EWVEpC8sAE54neyPV/pUpyB3KW8p/8rVr3s8itaQ8J2Ylq2YPTPjwGf1uMupOsUl874vHTFkV5jstWFedntzxGPrsigLaVf92KQrzcAEt6xibKr80EofHKNJz1ZCnOvqQR/aUH41JYiaDhZBNGDEg0oyA0wrNyrQLCCtG9k669hhrg/KGdbJQJrP+P6n17Rzhb3hikKhiDXRTxSfErZgdXmt6ZQ9myKEbIpHjh/5+t0w1F7mrSjr3QT4ueeQNjEbKyd/5AZqVpTa+Gf/Jbw="


### PR DESCRIPTION
Make sure the GitHub Actions self-hosted runner points to the new one.