### PR TITLE
Update sign.yml to only run it's jobs on windows-2022

### DIFF
--- a/.github/workflows/actions-example.yml
+++ b/.github/workflows/actions-example.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   build:
-    runs-on: windows-latest
+    runs-on: windows-2022
     outputs:
       job1: ${{ steps.generate.outputs.job }}
     steps:
@@ -39,7 +39,7 @@ jobs:
   
   attach:
     needs: sign
-    runs-on: windows-latest
+    runs-on: windows-2022
     steps:
     # you can apply multiple signature by calling apply-signed-digest many times,
     # provided you reference each invocation's artifact and digest pair separately.

--- a/.github/workflows/sign-digest.yml
+++ b/.github/workflows/sign-digest.yml
@@ -3,6 +3,7 @@ on:
   workflow_dispatch:
     inputs:
       provider:
+        description: The security token provider.
         default: "LsDevSectigoEV"
         type: string
       job:

--- a/.github/workflows/sign-example.yml
+++ b/.github/workflows/sign-example.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   build:
-    runs-on: windows-latest
+    runs-on: windows-2022
     steps:
     - uses: actions/checkout@v4
     
@@ -32,7 +32,7 @@ jobs:
       certificate: ${{ secrets.CODESIGN_LSDEVSECTIGOEV }}
 
   test:
-    runs-on: windows-latest
+    runs-on: windows-2022
     needs: sign
     env:
       signtool: C:/"Program Files (x86)"/"Windows Kits"/10/bin/10.0.17763.0/x86/signtool.exe

--- a/.github/workflows/sign-example.yml
+++ b/.github/workflows/sign-example.yml
@@ -24,7 +24,7 @@ jobs:
 
   sign:
     needs: build
-    uses: sillsdev/codesign/.github/workflows/sign.yml@v2.1
+    uses: sillsdev/codesign/.github/workflows/sign.yml@fix/workflow-based-signing-fails-on-windows-2025
     with:
       artifact: grcompiler
       description: Graphite

--- a/.github/workflows/sign-example.yml
+++ b/.github/workflows/sign-example.yml
@@ -24,7 +24,7 @@ jobs:
 
   sign:
     needs: build
-    uses: sillsdev/codesign/.github/workflows/sign.yml@fix/workflow-based-signing-fails-on-windows-2025
+    uses: sillsdev/codesign/.github/workflows/sign.yml@v2
     with:
       artifact: grcompiler
       description: Graphite

--- a/.github/workflows/sign.yml
+++ b/.github/workflows/sign.yml
@@ -27,7 +27,7 @@ env:
 
 jobs:
   digest:
-    runs-on: windows-latest
+    runs-on: windows-2022
     outputs:
       job: ${{ steps.generate.outputs.job }}
     steps:
@@ -52,7 +52,7 @@ jobs:
    
   finalise:
     needs: remotesign
-    runs-on: windows-latest
+    runs-on: windows-2022
     steps:
     - uses: sillsdev/codesign/apply-signed-digest@v2.1
       with:


### PR DESCRIPTION
Due to the SDK use when this workflow was first written being replaced with a newer version in the windows-2025 image, the workflow based sign.yaml workflow fails when trying to call `signtool`.