### PR TITLE
Make credential param optional with sensible SIL default

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,20 @@ Please see further down for the documentation for the original [v2 documentation
 
 All the actions in the repo will only run on a windows runner, the GitHub hosted windows runner will work, as will self-hosted runners with Windows 7+ which have Powershell 5.1+, and .NET runtime 6.0+
 
-## Example
+#### Default Credentials
+The action will automatically use the `TRUSTED_SIGNING_CREDENTIALS` organization secret if it's available for your repository. If this secret is not enabled for your repo, you'll get a helpful error message explaining how to fix it.
+
+## Super Simple Example
+
+```yaml
+- name: Sign Windows Installer
+  uses: sillsdev/codesign/trusted-signing-action@v3
+  with:
+    files-folder: dist
+    files-folder-filter: *.exe
+```
+
+## Another Example
 
 An example from an MSIX packaged app:
 ```yaml
@@ -42,13 +55,49 @@ This Action connects to the Azure service via OpenID Connect only, we do not sup
   "account-name": "<account name>"
 }
 ```
-We provide this bundle as an Organizational secret visible to selected repos called `TRUSTED_SIGNING_CREDENTIALS`.
+
+#### Manual Credentials
+You can also explicitly provide credentials by passing them via the `credentials` input:
+```yaml
+- name: Sign with Trusted Signing
+  uses: sillsdev/codesign/trusted-signing-action@v3
+  with:
+    credentials: ${{ secrets.YOUR_CUSTOM_CREDENTIALS }}
+    # ... other parameters
+```
 
 ### Test signing
 ```yaml
 use-test-certificate: true
 ```
 Tells the signing service to use our Public Trust Test certificate, instead of the production certificate. This certificate is guarenteed not validate. Defaults to 'false'.
+
+## Troubleshooting
+
+### Credentials Not Available Error
+If you see an error like "Trusted Signing credentials are not available", this means:
+
+1. **Organization Secret Not Enabled**: The `TRUSTED_SIGNING_CREDENTIALS` organization secret hasn't been enabled for your repository
+2. **No Manual Credentials**: You haven't provided credentials via the `credentials` input
+
+**Solutions:**
+- **Ask a repository admin** to enable the `TRUSTED_SIGNING_CREDENTIALS` organization secret for your repository, OR
+- **Provide credentials manually** by adding your own secret and using:
+  ```yaml
+  credentials: ${{ secrets.YOUR_CREDENTIALS_SECRET }}
+  ```
+
+### Invalid Credentials Error
+If the credentials are present but invalid, check that your JSON contains all required fields:
+```json
+{
+  "tenant-id": "<Entra Directory ID>",
+  "client-id": "<Entra Application ID>", 
+  "client-secret": "<Secret value, not secret ID>",
+  "endpoint": "<endpoint for your country>",
+  "account-name": "<account name>"
+}
+```
 
 
 ## `azure/trusted-signing-action` parameters

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ You can also explicitly provide credentials by passing them via the `credentials
 ```yaml
 use-test-certificate: true
 ```
-Tells the signing service to use our Public Trust Test certificate, instead of the production certificate. This certificate is guarenteed not validate. Defaults to 'false'.
+Tells the signing service to use our Public Trust Test certificate, instead of the production certificate. This certificate is guaranteed not to validate. Defaults to 'false'.
 
 ## Troubleshooting
 

--- a/trusted-signing-action/action.yml
+++ b/trusted-signing-action/action.yml
@@ -12,8 +12,10 @@ inputs:
   # }
   credentials:
     description: A JSON object containing the credentials to authenticate us to the Trusted Signing Service,
-                 the individual secrets will be masked in the logs.
-    required: true
+                 the individual secrets will be masked in the logs. Defaults to the TRUSTED_SIGNING_CREDENTIALS
+                 organization secret if available.
+    required: false
+    default: ${{ secrets.TRUSTED_SIGNING_CREDENTIALS }}
   use-test-certificate:
     description: Use the Public Trust Test certificate for signing. This will allow signing to complete
                  as normal. However it uses a certificate from an unverifiable root of trust, preventing
@@ -97,7 +99,38 @@ runs:
       script: |
         const test_cert = JSON.parse(process.env.testing_mode)
         const profile_name = test_cert ? "sil-codesign-test" : "sil-codesign-production"
+        
+        // Check if credentials are available
+        if (!process.env.credentials || process.env.credentials === '' || process.env.credentials === 'null') {
+          core.setFailed('❌ Trusted Signing credentials are not available. This usually means:\n\n' +
+            '1. The TRUSTED_SIGNING_CREDENTIALS organization secret is not enabled for this repository\n' +
+            '2. You need to explicitly pass credentials via the "credentials" input parameter\n\n' +
+            'To fix this:\n' +
+            '• Ask a repository admin to enable the TRUSTED_SIGNING_CREDENTIALS organization secret for this repo, OR\n' +
+            '• Pass credentials explicitly: credentials: ${{ secrets.YOUR_CREDENTIALS_SECRET }}\n\n' +
+            'For more information, see the action documentation.')
+          return
+        }
+        
         const credentials = JSON.parse(atob(process.env.credentials))
+        
+        // Validate that all required credential fields are present
+        const requiredFields = ['tenant-id', 'client-id', 'client-secret', 'endpoint', 'account-name']
+        const missingFields = requiredFields.filter(field => !credentials[field])
+        
+        if (missingFields.length > 0) {
+          core.setFailed(`❌ Missing required credential fields: ${missingFields.join(', ')}\n\n` +
+            'The credentials JSON must contain all required fields:\n' +
+            '{\n' +
+            '  "tenant-id": "<Entra Directory ID>",\n' +
+            '  "client-id": "<Entra Application ID>",\n' +
+            '  "client-secret": "<Secret value, not secret ID>",\n' +
+            '  "endpoint": "<endpoint for your country>",\n' +
+            '  "account-name": "<account name>"\n' +
+            '}')
+          return
+        }
+        
         core.setSecret(credentials["tenant-id"])
         core.setSecret(credentials["client-id"])
         core.setSecret(credentials["client-secret"])


### PR DESCRIPTION
This change is all about not requiring action consumers to provide the boilerplate
`credentials: ${{ secrets.TRUSTED_SIGNING_CREDENTIALS }}`
This becomes the default value and can be left out

Also in this change:
- add documentation about this change
- add a nice error message with suggested solutions when credentials not available
- error checking for JSON credential fields

WANTED: Somebody to actually test this change in their action to see if it works